### PR TITLE
masto: fixed pkg/api call

### DIFF
--- a/src/social/clj/bots/mastodon.cljs
+++ b/src/social/clj/bots/mastodon.cljs
@@ -12,12 +12,9 @@
   "public toot"
   [status visibility key token]
   (nbb/await
-   (p/let [cli (masto token)
-           v1 (.-v1 cli)
-           body (.create
-                 (.-statuses v1)
-                 #js {:status status
-                      :visibility visibility})
+   (p/let [body (.create (.. (masto token) -v1 -statuses)
+                         #js {:status status
+                              :visibility visibility})
            obj (js->clj body)
            id (get obj "id")
            createdat (get obj "createdAt")]


### PR DESCRIPTION
had done the update #67, but was bugged in the mastojs api call
now the login is no longer async

ref: https://github.com/neet/masto.js/releases/tag/v6.0.0